### PR TITLE
track upstream 1.1-rc1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,17 @@
 FROM registry.access.redhat.com/ubi8/go-toolset:latest as builder
 ENV GOPATH=/go/
+ENV GO111MODULE=on
 USER root
-RUN mkdir -p /go/src/github.com/prometheus-community/jiralert
 WORKDIR /go/src/github.com/prometheus-community/jiralert
-RUN go get github.com/prometheus/promu
-RUN git clone --progress --verbose https://github.com/prometheus-community/jiralert.git .
-RUN $(go env GOPATH)/bin/promu build
+RUN git clone \
+    -b 1.1-rc1 \
+    https://github.com/prometheus-community/jiralert.git .
+RUN make
 
 FROM registry.access.redhat.com/ubi8-minimal:8.2
-RUN microdnf update -y && rm -rf /var/cache/yum && microdnf install ca-certificates
+RUN microdnf update -y \
+    && rm -rf /var/cache/yum \
+    && microdnf install ca-certificates
 WORKDIR /
 COPY --from=builder /go/src/github.com/prometheus-community/jiralert/jiralert /usr/bin
 ENTRYPOINT ["/usr/bin/jiralert"]

--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -exv
 
+DOCKER_COMMAND="${DOCKER_COMMAND:-docker}"
+
 BASE_IMG="jiralert"
 QUAY_IMAGE="quay.io/app-sre/${BASE_IMG}"
 IMG="${BASE_IMG}:latest"
@@ -8,10 +10,11 @@ IMG="${BASE_IMG}:latest"
 GIT_HASH=`git rev-parse --short=7 HEAD`
 
 # build the image
-docker build  --no-cache \
-              --force-rm \
-              -t ${IMG}  \
-              -f ./Dockerfile .
+$DOCKER_COMMAND build \
+    --no-cache \
+    --force-rm \
+    -t ${IMG} \
+    -f ./Dockerfile .
 
 # push the image
 skopeo copy --dest-creds "${QUAY_USER}:${QUAY_TOKEN}" \


### PR DESCRIPTION
- make docker command configurable for build script via optional DOCKER_COMMAND envvar (needed on my machine to run `DOCKER_COMMAND='sudo docker' ./build_deploy.sh`
- use upstream build process and build v1.1-rc1